### PR TITLE
Migrated build process to be compatible with go 1.9.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ ZFS_POOL main.defaultZfsPool"); do
             ldflags="${ldflags} "
         fi
         envval=$(head -n1 "env/${envvar}")
-        ldflags="${ldflags}-X ${govar} ${envval}"
+        ldflags="${ldflags}-X ${govar}=${envval}"
         echo "info:     found var ${envvar}, value=${envval}"
     fi
 done

--- a/src/config.go
+++ b/src/config.go
@@ -68,7 +68,7 @@ var (
 // LDFLAGS can be specified by compiling with `-ldflags '-X main.defaultSshHost=.. ...'`.
 var (
 	build                     string
-	defaultHaProxyStats       bool
+	defaultHaProxyStats       string
 	defaultHaProxyCredentials string
 	defaultAwsKey             string
 	defaultAwsSecret          string
@@ -667,7 +667,7 @@ func HaProxyStatsEnabled() bool {
 	if maybeValue != "" {
 		return maybeValue == "1" || maybeValue == "true" || maybeValue == "yes"
 	}
-	return defaultHaProxyStats
+	return defaultHaProxyStats == "1" || defaultHaProxyStats == "true" || defaultHaProxyStats == "yes"
 }
 
 func HaProxyCredentials() string {


### PR DESCRIPTION
Migrated build process to be compatible with go 1.9.

    - Linker var specification now requires '=', e.g. `-X key=value'.

    - Linker no longer permits specifying bool variable values; refactored
      `defaultHaProxyStats' to be a string.

Fixes #21.